### PR TITLE
The newest versions of dtale only accept integers as valid data ids; …

### DIFF
--- a/dtale_desktop/dtale_app.py
+++ b/dtale_desktop/dtale_app.py
@@ -29,7 +29,21 @@ def run():
     )
 
 
+def _format_data_id(data_id: Union[str, int]) -> int:
+    """
+    Dtale-desktop was previously using hexadecimal strings as data IDs, but new versions of dtale (>1.35)
+    now only support integers as data IDs.
+
+    This function will serve as a temporary adapter, ensuring that all communication with the dtale app
+    uses integers.
+    """
+    if isinstance(data_id, str):
+        return int(data_id, 16)
+    return data_id
+
+
 def get_instance(data_id: Union[str, int]) -> Union[dtale.app.DtaleData, None]:
+    data_id = _format_data_id(data_id)
     return dtale.app.get_instance(data_id)
 
 
@@ -37,27 +51,32 @@ def launch_instance(data: pd.DataFrame, data_id: str) -> dtale.app.DtaleData:
     return dtale.app.startup(
         DTALE_INTERNAL_ROOT_URL,
         data=data,
-        data_id=data_id,
+        data_id=_format_data_id(data_id),
         ignore_duplicate=True,
         allow_cell_edits=not settings.DISABLE_DTALE_CELL_EDITS,
     )
 
 
 def get_main_url(data_id: str) -> str:
+    data_id = _format_data_id(data_id)
     return urljoin(DTALE_EXTERNAL_ROOT_URL, f"/dtale/main/{data_id}")
 
 
 def get_charts_url(data_id: str) -> str:
+    data_id = _format_data_id(data_id)
     return urljoin(DTALE_EXTERNAL_ROOT_URL, f"/dtale/charts/{data_id}")
 
 
 def get_describe_url(data_id: str) -> str:
+    data_id = _format_data_id(data_id)
     return urljoin(DTALE_EXTERNAL_ROOT_URL, f"/dtale/popup/describe/{data_id}")
 
 
 def get_correlations_url(data_id: str) -> str:
+    data_id = _format_data_id(data_id)
     return urljoin(DTALE_EXTERNAL_ROOT_URL, f"/dtale/popup/correlations/{data_id}")
 
 
 def kill_instance(data_id: str) -> None:
+    data_id = _format_data_id(data_id)
     global_state.cleanup(data_id)

--- a/tests/test_dtale_app.py
+++ b/tests/test_dtale_app.py
@@ -1,3 +1,4 @@
+from hashlib import md5
 import pandas as pd
 import pytest
 
@@ -23,15 +24,14 @@ def data():
 
 @pytest.fixture
 def data_id():
-    return "abc123"
+    return md5("abc123".encode("utf8")).hexdigest()
 
 
 def test_launch_instance(dtale_app, data, data_id):
     instance = dtale_app.launch_instance(data=data, data_id=data_id)
-    assert instance.is_up()
     assert (
         instance.main_url()
-        == f"{dtale_app.DTALE_EXTERNAL_ROOT_URL}/dtale/main/{data_id}"
+        == f"{dtale_app.DTALE_EXTERNAL_ROOT_URL}/dtale/main/{dtale_app._format_data_id(data_id)}"
     )
     pd.testing.assert_frame_equal(data, instance.data)
 


### PR DESCRIPTION
…dtale-desktop was using hex strings, so as a temporary fix each hex string will be converted to an integer before being passed to the dtale app